### PR TITLE
feat:move error descriptor to commmon

### DIFF
--- a/authentication/authentication.proto
+++ b/authentication/authentication.proto
@@ -55,13 +55,7 @@ enum LoginErrorState {
 }
 
 message LoginErrorResponse {
-  message ErrorDescriptor {
-    string message = 1;
-    string field = 2;
-    string rule = 3;
-  }
-
-  repeated ErrorDescriptor descriptors = 1;
+  repeated common.ErrorDescriptor descriptors = 1;
   int32 attempts_remaining = 2;
 }
 

--- a/common/common.proto
+++ b/common/common.proto
@@ -16,3 +16,9 @@ message EmptyReply {}
 
 // EmptyRequest provides a request that contains nothing
 message EmptyRequest {}
+
+message ErrorDescriptor {
+  string message = 1;
+  string field = 2;
+  string rule = 3;
+}


### PR DESCRIPTION
`ErrorDescriptor` can be reused, proposing move to common